### PR TITLE
Twitter authentication via OAuth2

### DIFF
--- a/server/MANIFEST.in
+++ b/server/MANIFEST.in
@@ -1,2 +1,2 @@
 include *.txt *.ini *.cfg *.rst
-recursive-include mediapublic *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.js *.html *.xml
+recursive-include mediapublic *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.jinja2 *.js *.html *.xml

--- a/server/development.ini
+++ b/server/development.ini
@@ -3,7 +3,12 @@
 # http://docs.pylonsproject.org/projects/pyramid/en/1.5-branch/narr/environment.html
 ###
 
-[app:main]
+[composite:main]
+use = egg:Paste#urlmap
+/ = mediapublic
+/auth = velruse
+
+[app:mediapublic]
 use = egg:mediapublic
 
 pyramid.reload_templates = true
@@ -13,6 +18,7 @@ pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_tm
+    pyramid_jinja2
 
 sqlalchemy.url = sqlite:///%(here)s/mediapublic.sqlite
 

--- a/server/development.ini
+++ b/server/development.ini
@@ -31,7 +31,7 @@ sqlalchemy.url = sqlite:///%(here)s/mediapublic.sqlite
 ###
 
 [server:main]
-use = egg:waitress#main
+use = egg:Paste#http
 host = 0.0.0.0
 port = 6543
 
@@ -41,7 +41,7 @@ port = 6543
 ###
 
 [loggers]
-keys = root, mediapublic, sqlalchemy
+keys = root, mediapublic, velruse, sqlalchemy
 
 [handlers]
 keys = console
@@ -57,6 +57,11 @@ handlers = console
 level = DEBUG
 handlers =
 qualname = mediapublic
+
+[logger_velruse]
+level = DEBUG
+handlers =
+qualname = velruse
 
 [logger_sqlalchemy]
 level = WARN

--- a/server/development.ini
+++ b/server/development.ini
@@ -22,6 +22,25 @@ pyramid.includes =
 
 sqlalchemy.url = sqlite:///%(here)s/mediapublic.sqlite
 
+
+[app:velruse]
+use = egg:velruse
+
+#setup = mediapublic.setup_velruse
+
+velruse.providers =
+	velruse.providers.twitter
+
+session.secret = notverysecret
+endpoint = /login
+store = sqla
+store.url = sqlite:///%(here)s/mediapublic.sqlite
+
+provider.twitter.consumer_key = XXXXXXXXX
+provider.twitter.consumer_secret = YYYYYYYYY
+provider.twitter.authorize = true
+
+
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1

--- a/server/development.ini
+++ b/server/development.ini
@@ -21,6 +21,7 @@ pyramid.includes =
     pyramid_jinja2
 
 sqlalchemy.url = sqlite:///%(here)s/mediapublic.sqlite
+mediapublic.authentication_secret = secretstuff
 
 
 [app:velruse]

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -1,6 +1,8 @@
+from pyramid import authentication
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
 
+from .auth import associate_groups
 from .models import (
     DBSession,
     Base,
@@ -17,7 +19,15 @@ def main(global_config, **settings):
         settings=settings,
     )
 
-    config.set_authentication_policy('mediapublic.auth.authn_policy')
+    config.set_authentication_policy(
+        authentication.AuthTktAuthenticationPolicy(
+            # TODO(ryansb): load this from config
+            config.get_settings().get('mediapublic.authentication_secret',
+                                      'changeme'),
+            callback=associate_groups,
+            hashalg='sha512',
+        )
+    )
     config.set_authorization_policy('mediapublic.auth.authz_policy')
     config.add_permission('get')
     config.add_permission('create')

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -1,5 +1,6 @@
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
+from pyramid.session import UnencryptedCookieSessionFactoryConfig
 
 from .models import (
     DBSession,
@@ -10,10 +11,15 @@ from .models import (
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
+    session_factory = UnencryptedCookieSessionFactoryConfig('itsaseekreet')
+
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
     Base.metadata.bind = engine
-    config = Configurator(settings=settings)
+    config = Configurator(
+        settings=settings,
+        session_factory=session_factory,
+    )
     config.include('cornice')
     config.scan('mediapublic.views')
 

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -21,7 +21,6 @@ def main(global_config, **settings):
 
     config.set_authentication_policy(
         authentication.AuthTktAuthenticationPolicy(
-            # TODO(ryansb): load this from config
             config.get_settings().get('mediapublic.authentication_secret',
                                       'changeme'),
             callback=associate_groups,

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -1,6 +1,5 @@
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
-from pyramid.session import UnencryptedCookieSessionFactoryConfig
 
 from .models import (
     DBSession,
@@ -11,14 +10,11 @@ from .models import (
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
-    session_factory = UnencryptedCookieSessionFactoryConfig('itsaseekreet')
-
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
     Base.metadata.bind = engine
     config = Configurator(
         settings=settings,
-        session_factory=session_factory,
     )
     config.include('cornice')
     config.scan('mediapublic.views')

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -16,7 +16,16 @@ def main(global_config, **settings):
     config = Configurator(
         settings=settings,
     )
+
+    config.set_authentication_policy('mediapublic.auth.authn_policy')
+    config.set_authorization_policy('mediapublic.auth.authz_policy')
+    config.add_permission('get')
+    config.add_permission('create')
+    config.add_permission('update')
+    config.add_permission('delete')
+
     config.include('cornice')
+    config.scan('mediapublic.auth')
     config.scan('mediapublic.views')
 
     config.include('velruse.providers.twitter')

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -23,4 +23,6 @@ def main(global_config, **settings):
     config.include('cornice')
     config.scan('mediapublic.views')
 
+    config.include('velruse.providers.twitter')
+
     return config.make_wsgi_app()

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -1,12 +1,13 @@
 from pyramid import authentication
 from pyramid.config import Configurator
+from pyramid import security
 from sqlalchemy import engine_from_config
 
-from .auth import associate_groups
+from mediapublic import auth
 from .models import (
     DBSession,
     Base,
-    )
+)
 
 
 def main(global_config, **settings):
@@ -23,7 +24,7 @@ def main(global_config, **settings):
         authentication.AuthTktAuthenticationPolicy(
             config.get_settings().get('mediapublic.authentication_secret',
                                       'changeme'),
-            callback=associate_groups,
+            callback=auth.associate_groups,
             hashalg='sha512',
         )
     )

--- a/server/mediapublic/auth.py
+++ b/server/mediapublic/auth.py
@@ -52,8 +52,9 @@ def users_acl(request):
 
 
 def associate_groups(user_id, request):
-    # TODO(ryansb): maybe we need more than one group type.
-    return 'user',
+    # TODO(ryansb): actually associate users/groups using the
+    # UserTypes model
+    return 'user', 'admin'
 
 
 authn_policy = authentication.AuthTktAuthenticationPolicy(

--- a/server/mediapublic/auth.py
+++ b/server/mediapublic/auth.py
@@ -29,7 +29,6 @@ default_acl = [
 
 
 class Context(object):
-    __acl__ = None
     def __init__(self, acl):
         """`acl` is a list of triples (result, principal, permission)"""
         self.__acl__ = acl[:]

--- a/server/mediapublic/auth.py
+++ b/server/mediapublic/auth.py
@@ -37,9 +37,17 @@ class Context(object):
 
 def choose_context(request):
     # request.matched_route.name
+    if request.registry.settings.get(
+            'mediapublic.ignore_authentication'):
+        return Context([
+            (security.Allow, security.Everyone, 'get'),
+            (security.Allow, security.Everyone, 'create'),
+            (security.Allow, security.Everyone, 'update'),
+            (security.Allow, security.Everyone, 'delete'),
+        ])
     acl = default_acl[:]
-    if ('usersresource' in request.matched_route.name
-            and request.authenticated_userid):
+    if ('usersresource' in request.matched_route.name and
+            request.authenticated_userid):
         acl.append(
             (security.Allow, request.authenticated_userid, 'update')
         )

--- a/server/mediapublic/auth.py
+++ b/server/mediapublic/auth.py
@@ -1,0 +1,93 @@
+import json
+import logging
+
+from cornice import Service
+from pyramid import (
+    authentication,
+    authorization,
+    security,
+)
+
+import requests
+
+from .constants import cors_policies
+from .models import Users
+
+log = logging.getLogger(name="mediapublic.{}".format(__name__))
+
+
+resource_acl = [
+    (security.Allow, security.Everyone, 'get'),
+    (security.Allow, 'group:writers', 'create'),
+    (security.Allow, 'group:writers', 'update'),
+    (security.Allow, 'group:admins', 'delete'),
+]
+
+
+def default_acl(request):
+    pass
+
+
+def users_acl(request):
+    if request.authenticated_userid:
+        pass
+
+
+def associate_groups(user_id, request):
+    # TODO(ryansb): maybe we need more than one group type.
+    return 'user',
+
+
+authn_policy = authentication.AuthTktAuthenticationPolicy(
+    # TODO(ryansb): load this from config
+    'secretsecrets',
+    callback=associate_groups,
+    hashalg='sha512',
+)
+
+
+authz_policy = authorization.ACLAuthorizationPolicy()
+
+
+# --------- Auth and login
+login = Service(name='login', path='/login', description="Auth and such")
+
+
+@login.get(renderer="mediapublic:templates/login.jinja2", **cors_policies)
+def login_form(request):
+    print(request.params)
+    return {"foo": "bar"}
+
+
+@login.post(renderer="mediapublic:templates/logged_in.jinja2", **cors_policies)
+def logged_in(request):
+    log.debug("Received auth, token ID %s" % request.params['token'])
+    resp = requests.get(request.host_url + '/auth/auth_info', params={
+        'format': 'json',
+        'token': request.params['token'],
+    })
+    # Future feature: when using providers other than twitter, check
+    # auth_info['provider_name'] to see where the account is from
+    auth_info = resp.json()
+    twitter_handle = auth_info["profile"]["accounts"][0]['username']
+    log.debug("Login for @%s" % twitter_handle)
+
+    log.debug("Auth data: %s" % json.dumps(auth_info, indent=4))
+    already_exists, uid = Users.update_social_login(twitter_handle, auth_info)
+
+    log.debug("Succesfully authenticated @%s with twitter, exists:%s" %
+              (twitter_handle, already_exists))
+
+    principals = security.remember(request, str(uid))
+    request.response.headerlist.extend(principals)
+    log.debug("User authenticated, sending back %s" %
+              request.response.headers)
+
+    return {'exists': already_exists, 'handle': twitter_handle}
+
+
+@login.delete(**cors_policies)
+def logout(request):
+    principals = security.forget(request)
+    request.response.headerlist.extend(principals)
+    return {"success": True}

--- a/server/mediapublic/constants.py
+++ b/server/mediapublic/constants.py
@@ -1,0 +1,7 @@
+cors_policies = dict(
+    cors_enabled=True,
+    cors_origins=('*', ),
+    cors_max_age=1728000,
+    cors_headers=('Origin' 'Content-Type', 'Accept', 'Authorization'),
+    cors_credentials=True,
+)

--- a/server/mediapublic/models.py
+++ b/server/mediapublic/models.py
@@ -121,17 +121,17 @@ class Users(Base, CreationMixin, TimeStampMixin):
     __tablename__ = 'users'
 
     id = Column(UUIDType(binary=False), primary_key=True)
+    display_name = Column(UnicodeText, nullable=False)
     email = Column(UnicodeText, nullable=False)
     last_longin_datetime = Column(DateTime, server_default=func.now())
 
-    signup_date = Column(DateTime, nullable=False, server_default=func.now())
+    signup_date = Column(DateTime, server_default=func.now())
 
     twitter_handle = Column(UnicodeText, unique=True)
     twitter_user_id = Column(UnicodeText, unique=True)
     twitter_auth_token = Column(UnicodeText)
     twitter_auth_secret = Column(UnicodeText)
     profile_photo_url = Column(UnicodeText)
-    display_name = Column(UnicodeText)
 
     user_type_id = Column(ForeignKey('user_types.id'))
     organization_id = Column(ForeignKey('organizations.id'))
@@ -144,8 +144,10 @@ class Users(Base, CreationMixin, TimeStampMixin):
                 display_name=auth_info["profile"]["name"]["formatted"],
                 twitter_handle=str(social_uname),
                 profile_photo_url=auth_info["profile"]["photos"][0]["value"],
-                twitter_auth_secret=auth_info["credentials"]["oauthAccessTokenSecret"],
-                twitter_auth_token=auth_info["credentials"]["oauthAccessToken"],
+                twitter_auth_secret=auth_info[
+                    "credentials"]["oauthAccessTokenSecret"],
+                twitter_auth_token=auth_info[
+                    "credentials"]["oauthAccessToken"],
                 twitter_user_id=auth_info["profile"]["accounts"][0]['userid'],
             )
         except IntegrityError:
@@ -154,9 +156,12 @@ class Users(Base, CreationMixin, TimeStampMixin):
                     cls.twitter_handle == str(social_uname),
                 ).update(
                     values=dict(
-                        twitter_auth_secret=auth_info["credentials"]["oauthAccessTokenSecret"],
-                        twitter_auth_token=auth_info["credentials"]["oauthAccessToken"],
-                        twitter_user_id=auth_info["profile"]["accounts"][0]['userid'],
+                        twitter_auth_secret=auth_info[
+                            "credentials"]["oauthAccessTokenSecret"],
+                        twitter_auth_token=auth_info[
+                            "credentials"]["oauthAccessToken"],
+                        twitter_user_id=auth_info[
+                            "profile"]["accounts"][0]['userid'],
                     )
                 )
                 user = DBSession.query(cls).filter(
@@ -165,7 +170,6 @@ class Users(Base, CreationMixin, TimeStampMixin):
             return True, user.id
 
         return False, user.id
-
 
     def to_dict(self):
         resp = super(Users, self).to_dict()

--- a/server/mediapublic/models.py
+++ b/server/mediapublic/models.py
@@ -374,7 +374,7 @@ class People(Base, CreationMixin, TimeStampMixin):
     secondary_website = Column(UnicodeText, nullable=False)
 
     # these should probably be brough out into a seperate table as
-    # many to one so we don't have to keep adding colyumns ...
+    # many to one so we don't have to keep adding columns ...
     twitter = Column(UnicodeText, nullable=False)
     facebook = Column(UnicodeText, nullable=False)
     instagram = Column(UnicodeText, nullable=False)

--- a/server/mediapublic/models.py
+++ b/server/mediapublic/models.py
@@ -123,8 +123,13 @@ class Users(Base, CreationMixin, TimeStampMixin):
     first = Column(UnicodeText, nullable=False)
     last = Column(UnicodeText, nullable=False)
     email = Column(UnicodeText, nullable=False)
-    twitter = Column(UnicodeText, nullable=False)
     last_longin_datetime = Column(DateTime)
+
+    signup_date = Column(DateTime, nullable=False, server_default=func.now())
+
+    twitter_id = Column(UnicodeText, unique=True)
+    twitter_auth_token = Column(UnicodeText, unique=True)
+    twitter_auth_secret = Column(UnicodeText, unique=True)
 
     user_type_id = Column(ForeignKey('user_types.id'))
     organization_id = Column(ForeignKey('organizations.id'))

--- a/server/mediapublic/models.py
+++ b/server/mediapublic/models.py
@@ -139,9 +139,10 @@ class Users(Base, CreationMixin, TimeStampMixin):
     @classmethod
     def update_social_login(cls, social_uname, auth_info, provider='twitter'):
         try:
-            Users.add(
+            user = Users.add(
                 email="%s@%s.social.auth" % (social_uname, provider),
                 display_name=auth_info["profile"]["name"]["formatted"],
+                twitter_handle=str(social_uname),
                 profile_photo_url=auth_info["profile"]["photos"][0]["value"],
                 twitter_auth_secret=auth_info["credentials"]["oauthAccessTokenSecret"],
                 twitter_auth_token=auth_info["credentials"]["oauthAccessToken"],

--- a/server/mediapublic/models.py
+++ b/server/mediapublic/models.py
@@ -154,23 +154,24 @@ class Users(Base, CreationMixin, TimeStampMixin):
                     cls.twitter_handle == str(social_uname),
                 ).update(
                     values=dict(
-                        display_name=auth_info["profile"]["name"]["formatted"],
-                        profile_photo_url=auth_info["profile"]["photos"][0]["value"],
                         twitter_auth_secret=auth_info["credentials"]["oauthAccessTokenSecret"],
                         twitter_auth_token=auth_info["credentials"]["oauthAccessToken"],
                         twitter_user_id=auth_info["profile"]["accounts"][0]['userid'],
                     )
                 )
-            return True
+                user = DBSession.query(cls).filter(
+                    cls.twitter_handle == str(social_uname)
+                ).first()
+            return True, user.id
 
-        return False
+        return False, user.id
 
 
     def to_dict(self):
         resp = super(Users, self).to_dict()
         resp.update(
-            first=self.first,
-            last=self.last,
+            display_name=self.display_name,
+            twitter_handle=self.twitter_handle,
             email=self.email,
             user_type=self.user_type_id,
             organization_id=self.organization_id,

--- a/server/mediapublic/scripts/initializedb.py
+++ b/server/mediapublic/scripts/initializedb.py
@@ -30,7 +30,7 @@ def main(argv=sys.argv):
     config_uri = argv[1]
     options = parse_vars(argv[2:])
     setup_logging(config_uri)
-    settings = get_appsettings(config_uri, options=options)
+    settings = get_appsettings(config_uri, name='mediapublic', options=options)
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)

--- a/server/mediapublic/templates/logged_in.jinja2
+++ b/server/mediapublic/templates/logged_in.jinja2
@@ -1,3 +1,8 @@
 <html>
-<h3>Welcome, @{{ handle }}</h3>
+{% if exists %}
+<h3>Welcome back, @{{ handle }}</h3>
+{% else %}
+<h3>Welcome @{{ handle }}</h3>
+<p>Please enter an email to complete your profile.</p>
+{% endif %}
 </html>

--- a/server/mediapublic/templates/logged_in.jinja2
+++ b/server/mediapublic/templates/logged_in.jinja2
@@ -1,0 +1,3 @@
+<html>
+<h3>Welcome, @{{ handle }}</h3>
+</html>

--- a/server/mediapublic/templates/login.jinja2
+++ b/server/mediapublic/templates/login.jinja2
@@ -1,0 +1,5 @@
+<html>
+<form name="twitter" action="/auth/login/twitter" method="post">
+</form>
+<a class="twitter-button" href="javascript:document.twitter.submit();">Login with twitter</a>
+</html>

--- a/server/mediapublic/tests/gabbi.ini
+++ b/server/mediapublic/tests/gabbi.ini
@@ -14,6 +14,8 @@ pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_tm
 
+mediapublic.ignore_authentication = true
+
 sqlalchemy.url = sqlite:///%(here)s/mediapublic.sqlite
 
 # By default, the toolbar only appears for clients from IP addresses

--- a/server/mediapublic/tests/gabbits/user.yaml
+++ b/server/mediapublic/tests/gabbits/user.yaml
@@ -23,8 +23,7 @@ tests:
     method: POST
     url: /users
     data:
-      first: Joe
-      last: Test
+      display_name: Joe Test
       twitter: '@birds'
       email: 'test@foo.test'
 

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -142,14 +142,20 @@ def login_form(request):
 @login.post(renderer="mediapublic:templates/logged_in.jinja2", **cors_policies)
 def logged_in(request):
     log.debug("Received auth, token ID %s" % request.params['token'])
-    # Future feature: when using providers other than twitter, check
-    # auth_info['provider_name'] to see where the account is from
     resp = requests.get(request.host_url + '/auth/auth_info', params={
         'format': 'json',
         'token': request.params['token'],
     })
-    twitter_handle = resp.json()['profile']['preferredUsername']
-    log.debug("Succesfully authenticated @%s with twitter" % twitter_handle)
+    # Future feature: when using providers other than twitter, check
+    # auth_info['provider_name'] to see where the account is from
+    auth_info = resp.json()
+    twitter_handle = auth_info["profile"]["accounts"][0]['username']
+    log.debug("Login for @%s" % twitter_handle)
+
+    log.debug("Auth data: %s" % json.dumps(auth_info, indent=4))
+    user = Users.update_social_login(twitter_handle, auth_info)
+
+    log.debug("Succesfully authenticated @%s with twitter" % user.twitter_handle)
 
     return {'handle': twitter_handle}
 

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -1,10 +1,11 @@
 import logging
 import json
 import datetime
+import functools
 
 from cornice import Service
 from cornice.schemas import validate_colander_schema
-from cornice.resource import resource, view
+from cornice.resource import resource
 
 from .models import (
     DBSession,
@@ -20,8 +21,23 @@ from .models import (
     Playlists,
     PlaylistAssignments,
     )
-
 from .validators import validator_from_model
+
+from cornice.resource import view as raw_view
+
+cors_policies = dict(
+    cors_enabled=True,
+    cors_origins=('*', ),
+    cors_max_age=1728000,
+    cors_expose_all_headers=True,
+    cors_credentials=True,
+)
+
+view = functools.partial(
+    raw_view,
+    content_type="application/json",
+    **cors_policies
+)
 
 log = logging.getLogger(name="mediapublic.{}".format(__name__))
 
@@ -45,7 +61,7 @@ class ResourceMixin(object):
             self.rsrc: [i.to_dict() for i in self.cls.get_all()]
         }
 
-    @view(content_type="application/json", validators=('validate_req', ))
+    @view(validators=('validate_req', ))
     def collection_post(self):
         log.debug("collection_post on {} with {}".format(
             self.rsrc, json.dumps(self.request.validated)))
@@ -54,6 +70,7 @@ class ResourceMixin(object):
         self.request.response.status = 201
         return item.to_dict()
 
+    @view()
     def get(self):
         item = self.cls.get_by_id(self.request.matchdict['id'])
         if item is None:
@@ -61,7 +78,7 @@ class ResourceMixin(object):
             return {'error': 'Not found'}
         return item.to_dict()
 
-    @view(content_type="application/json", validators=('validate_req', ))
+    @view(validators=('validate_req', ))
     def put(self):
         item = self.cls.update_by_id(
             self.request.matchdict['id'],
@@ -74,6 +91,7 @@ class ResourceMixin(object):
         self.request.response.status = 201
         return item.to_dict()
 
+    @view()
     def delete(self):
         item = self.cls.delete_by_id(self.request.matchdict['id'])
         if item is None:
@@ -85,7 +103,7 @@ class ResourceMixin(object):
 status = Service(name='status', path='/status', description="Check app state")
 
 
-@status.get()
+@status.get(content_type='application/json', **cors_policies)
 def get_status(request):
     log.debug("Status check")
     status = {'web': True}

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -132,38 +132,6 @@ class UsersResource(ResourceMixin):
     cls = Users
 
 
-# --------- Auth and login
-login = Service(name='login', path='/login', description="Auth and such")
-
-
-@login.get(renderer="mediapublic:templates/login.jinja2", **cors_policies)
-def login_form(request):
-    print(request.params)
-    return {"foo": "bar"}
-
-
-@login.post(renderer="mediapublic:templates/logged_in.jinja2", **cors_policies)
-def logged_in(request):
-    log.debug("Received auth, token ID %s" % request.params['token'])
-    resp = requests.get(request.host_url + '/auth/auth_info', params={
-        'format': 'json',
-        'token': request.params['token'],
-    })
-    # Future feature: when using providers other than twitter, check
-    # auth_info['provider_name'] to see where the account is from
-    auth_info = resp.json()
-    twitter_handle = auth_info["profile"]["accounts"][0]['username']
-    log.debug("Login for @%s" % twitter_handle)
-
-    log.debug("Auth data: %s" % json.dumps(auth_info, indent=4))
-    already_exists = Users.update_social_login(twitter_handle, auth_info)
-
-    log.debug("Succesfully authenticated @%s with twitter, exists:%s" %
-              (twitter_handle, already_exists))
-
-    return {'exists': already_exists, 'handle': twitter_handle}
-
-
 @resource(collection_path='/user_types', path='/user_types/{id}')
 class UserTypesResource(ResourceMixin):
     """

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -119,7 +119,8 @@ def get_status(request):
     return status
 
 
-@resource(collection_path='/users', path='/users/{id}', cors_policy=cors_policy)
+@resource(collection_path='/users', path='/users/{id}',
+          cors_policy=cors_policy)
 class UsersResource(ResourceMixin):
     """
     [GET, POST             ] /users
@@ -168,7 +169,8 @@ class OrganizationsResource(ResourceMixin):
 # [GET,       PUT, DELETE] /howtos/{id}
 
 
-@resource(collection_path='/blogs', path='/blogs/{id}', cors_policy=cors_policy)
+@resource(collection_path='/blogs', path='/blogs/{id}',
+          cors_policy=cors_policy)
 class BlogsResource(ResourceMixin):
     """
     [GET, POST             ] /blogs

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -31,7 +31,6 @@ from cornice.resource import view as raw_view
 
 view = functools.partial(
     raw_view,
-    content_type="application/json",
     **cors_policies
 )
 
@@ -104,7 +103,7 @@ class ResourceMixin(object):
 status = Service(name='status', path='/status', description="Check app state")
 
 
-@status.get(content_type='application/json', **cors_policies)
+@status.get(permission=pyramid.security.NO_PERMISSION_REQUIRED, **cors_policies)
 def get_status(request):
     log.debug("Status check")
     status = {'web': True}

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -8,21 +8,24 @@ import requests
 from cornice import Service
 from cornice.schemas import validate_colander_schema
 from cornice.resource import resource
+from pyramid import security
 
+from .auth import login
+from .constants import cors_policies
 from .models import (
-    DBSession,
-    Users,
-    UserTypes,
-    RecordingCategories,
+    Blogs,
     Comments,
+    DBSession,
+    Howtos,
     Organizations,
     People,
-    Recordings,
-    Howtos,
-    Blogs,
-    Playlists,
     PlaylistAssignments,
-    )
+    Playlists,
+    RecordingCategories,
+    Recordings,
+    UserTypes,
+    Users,
+)
 from .validators import validator_from_model
 
 from cornice.resource import view as raw_view

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -100,7 +100,8 @@ class ResourceMixin(object):
 status = Service(name='status', path='/status', description="Check app state")
 
 
-@status.get(permission=pyramid.security.NO_PERMISSION_REQUIRED, **cors_policies)
+@status.get(permission=pyramid.security.NO_PERMISSION_REQUIRED,
+            **cors_policies)
 def get_status(request):
     log.debug("Status check")
     status = {'web': True}

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -29,7 +29,7 @@ cors_policies = dict(
     cors_enabled=True,
     cors_origins=('*', ),
     cors_max_age=1728000,
-    cors_expose_all_headers=True,
+    cors_headers=('Origin' 'Content-Type', 'Accept', 'Authorization'),
     cors_credentials=True,
 )
 

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -29,7 +29,6 @@ cors_policy = dict(
     enabled=True,
     origins=('*', ),
     max_age=1728000,
-    expose_all_headers=True,
     headers=('Origin', 'Content-Type', 'Accept', 'Authorization'),
     credentials=True,
 )

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -1,7 +1,6 @@
 import logging
 import json
 import datetime
-import functools
 
 from cornice import Service
 from cornice.schemas import validate_colander_schema
@@ -23,7 +22,7 @@ from .models import (
     )
 from .validators import validator_from_model
 
-from cornice.resource import view as raw_view
+from cornice.resource import view
 
 cors_policy = dict(
     enabled=True,
@@ -33,10 +32,6 @@ cors_policy = dict(
     credentials=True,
 )
 
-view = functools.partial(
-    raw_view,
-    content_type="application/json",
-)
 
 log = logging.getLogger(name="mediapublic.{}".format(__name__))
 

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -54,8 +54,6 @@ class ResourceMixin(object):
     @view(permission='get')
     def collection_get(self):
         log.debug("collection_get on {}".format(self.rsrc))
-        print(self._services.get('collection_usersresource'))
-        print(self.request.__dict__['matched_route'])
         return {
             self.rsrc: [i.to_dict() for i in self.cls.get_all()]
         }

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -153,11 +153,12 @@ def logged_in(request):
     log.debug("Login for @%s" % twitter_handle)
 
     log.debug("Auth data: %s" % json.dumps(auth_info, indent=4))
-    user = Users.update_social_login(twitter_handle, auth_info)
+    already_exists = Users.update_social_login(twitter_handle, auth_info)
 
-    log.debug("Succesfully authenticated @%s with twitter" % user.twitter_handle)
+    log.debug("Succesfully authenticated @%s with twitter, exists:%s" %
+              (twitter_handle, already_exists))
 
-    return {'handle': twitter_handle}
+    return {'exists': already_exists, 'handle': twitter_handle}
 
 
 @resource(collection_path='/user_types', path='/user_types/{id}')

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -25,18 +25,18 @@ from .validators import validator_from_model
 
 from cornice.resource import view as raw_view
 
-cors_policies = dict(
-    cors_enabled=True,
-    cors_origins=('*', ),
-    cors_max_age=1728000,
-    cors_headers=('Origin' 'Content-Type', 'Accept', 'Authorization'),
-    cors_credentials=True,
+cors_policy = dict(
+    enabled=True,
+    origins=('*', ),
+    max_age=1728000,
+    expose_all_headers=True,
+    headers=('Origin', 'Content-Type', 'Accept', 'Authorization'),
+    credentials=True,
 )
 
 view = functools.partial(
     raw_view,
     content_type="application/json",
-    **cors_policies
 )
 
 log = logging.getLogger(name="mediapublic.{}".format(__name__))
@@ -55,6 +55,7 @@ class ResourceMixin(object):
     def validate_req(self, request):
         validate_colander_schema(validator_from_model(self.cls), request)
 
+    @view()
     def collection_get(self):
         log.debug("collection_get on {}".format(self.rsrc))
         return {
@@ -100,10 +101,11 @@ class ResourceMixin(object):
         return item.to_dict()
 
 # --------- STATUS CHECK
-status = Service(name='status', path='/status', description="Check app state")
+status = Service(name='status', path='/status', description="Check app state",
+                 cors_policy=cors_policy)
 
 
-@status.get(content_type='application/json', **cors_policies)
+@status.get(content_type='application/json')
 def get_status(request):
     log.debug("Status check")
     status = {'web': True}
@@ -118,7 +120,7 @@ def get_status(request):
     return status
 
 
-@resource(collection_path='/users', path='/users/{id}')
+@resource(collection_path='/users', path='/users/{id}', cors_policy=cors_policy)
 class UsersResource(ResourceMixin):
     """
     [GET, POST             ] /users
@@ -127,7 +129,8 @@ class UsersResource(ResourceMixin):
     cls = Users
 
 
-@resource(collection_path='/user_types', path='/user_types/{id}')
+@resource(collection_path='/user_types', path='/user_types/{id}',
+          cors_policy=cors_policy)
 class UserTypesResource(ResourceMixin):
     """
     [GET, POST             ] /user_types
@@ -137,7 +140,7 @@ class UserTypesResource(ResourceMixin):
 
 
 @resource(collection_path='/recording_categories',
-          path='/recording_categories/{id}')
+          path='/recording_categories/{id}', cors_policy=cors_policy)
 class RecordingCategoriesResource(ResourceMixin):
     """
     [GET, POST             ] /recording_categories
@@ -146,7 +149,8 @@ class RecordingCategoriesResource(ResourceMixin):
     cls = RecordingCategories
 
 
-@resource(collection_path='/organizations', path='/organizations/{id}')
+@resource(collection_path='/organizations', path='/organizations/{id}',
+          cors_policy=cors_policy)
 class OrganizationsResource(ResourceMixin):
     """
     [GET, POST             ] /organizations
@@ -165,7 +169,7 @@ class OrganizationsResource(ResourceMixin):
 # [GET,       PUT, DELETE] /howtos/{id}
 
 
-@resource(collection_path='/blogs', path='/blogs/{id}')
+@resource(collection_path='/blogs', path='/blogs/{id}', cors_policy=cors_policy)
 class BlogsResource(ResourceMixin):
     """
     [GET, POST             ] /blogs

--- a/server/mediapublic/views.py
+++ b/server/mediapublic/views.py
@@ -122,7 +122,7 @@ def get_status(request):
 class UsersResource(ResourceMixin):
     """
     [GET, POST             ] /users
-    [GET,       PUT, DELETE] /users/:{id}
+    [GET,       PUT, DELETE] /users/{id}
     """
     cls = Users
 
@@ -141,7 +141,7 @@ class UserTypesResource(ResourceMixin):
 class RecordingCategoriesResource(ResourceMixin):
     """
     [GET, POST             ] /recording_categories
-    [GET,       PUT, DELETE] /recording_categories/:{id}
+    [GET,       PUT, DELETE] /recording_categories/{id}
     """
     cls = RecordingCategories
 
@@ -150,32 +150,32 @@ class RecordingCategoriesResource(ResourceMixin):
 class OrganizationsResource(ResourceMixin):
     """
     [GET, POST             ] /organizations
-    [GET,       PUT, DELETE] /organizations/:{id}
+    [GET,       PUT, DELETE] /organizations/{id}
     """
     cls = Organizations
 
 # --------- PEOPLE
 # [GET, POST             ] /people
-# [GET,       PUT, DELETE] /people/:{id}
+# [GET,       PUT, DELETE] /people/{id}
 # --------- RECORDINGS
 # [GET, POST             ] /recordings
-# [GET,       PUT, DELETE] /recordings/:{id}
+# [GET,       PUT, DELETE] /recordings/{id}
 # --------- HOWTOS
 # [GET, POST             ] /howtos
-# [GET,       PUT, DELETE] /howtos/:{id}
+# [GET,       PUT, DELETE] /howtos/{id}
 
 
 @resource(collection_path='/blogs', path='/blogs/{id}')
 class BlogsResource(ResourceMixin):
     """
     [GET, POST             ] /blogs
-    [GET,       PUT, DELETE] /blogs/:{id}
+    [GET,       PUT, DELETE] /blogs/{id}
     """
     cls = Blogs
 
 
 # --------- PLAYLISTS
 # [GET, POST             ] /playlists
-# [GET,       PUT, DELETE] /playlists/:{id}
-# [           PUT,       ] /playlists/:{id}/assign
-# [           PUT,       ] /playlists/:{id}/remove
+# [GET,       PUT, DELETE] /playlists/{id}
+# [           PUT,       ] /playlists/{id}/assign
+# [           PUT,       ] /playlists/{id}/remove

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,3 +8,4 @@ transaction
 waitress
 zope.sqlalchemy
 velruse
+pyramid_jinja2

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -9,3 +9,4 @@ waitress
 zope.sqlalchemy
 velruse
 pyramid_jinja2
+Paste

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,12 +1,13 @@
+Paste
 SQLAlchemy
 colander
 cornice
 pyramid
+pyramid_jinja2
 pyramid_tm
+requests
 sqlalchemy_utils
 transaction
+velruse
 waitress
 zope.sqlalchemy
-velruse
-pyramid_jinja2
-Paste

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,3 +7,4 @@ sqlalchemy_utils
 transaction
 waitress
 zope.sqlalchemy
+velruse


### PR DESCRIPTION
This is a pretty major change - it adds a sub-application called [Velruse](http://pythonhosted.org/velruse/) that handles authenticating against Twitter and accepting the OAauth2 handshake. It then exposes token data to our application. 

Currently, all it does is call Twitter, authenticate the user, and store their handle and other information in the database. In the future, logging in will lead new users to a prompt to add their email address and tweak their other profile information as they like. 
