### PR TITLE
Temporarily ignore authentication locally.

### DIFF
--- a/server/development.ini
+++ b/server/development.ini
@@ -23,6 +23,7 @@ pyramid.includes =
 sqlalchemy.url = sqlite:///%(here)s/mediapublic.sqlite
 mediapublic.authentication_secret = secretstuff
 cornice.handle_exceptions = False
+mediapublic.ignore_authentication = true
 
 
 [app:velruse]


### PR DESCRIPTION
We'll need to figure out this workflow eventually, but for now I've found it expedient to ignore authentication locally. I'll file an issue to document the need.
