### PR TITLE
Add JSON adapters for UUIDs and DateTimes.

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -24,7 +24,7 @@ Getting Started
 
 - `initialize_mediapublic_db development.ini`
 
-- `pserve development.ini`
+- `pserve development.ini --reload`
 
 Running Tests
 -------------

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -56,10 +56,13 @@ def main(global_config, **settings):
                     permission=security.NO_PERMISSION_REQUIRED)
 
     json_renderer = JSON()
+
     def uuid_adapter(obj, request):
-        return six.text_type(obj) if obj != None else None
+        return six.text_type(obj) if obj is not None else None
+
     def datetime_adapter(obj, request):
-        return six.text_type(obj) if obj != None else None
+        return six.text_type(obj) if obj is not None else None
+
     json_renderer.add_adapter(UUIDType, uuid_adapter)
     json_renderer.add_adapter(UUID, uuid_adapter)
     # json_renderer.add_adapter(DateTime, datetime_adapter)

--- a/server/mediapublic/__init__.py
+++ b/server/mediapublic/__init__.py
@@ -1,9 +1,11 @@
 import cornice.pyramidhook as hooks
-from pyramid import authentication
+from pyramid import authentication, httpexceptions, security
 from pyramid.config import Configurator
-from pyramid import security
-from sqlalchemy import engine_from_config
-from pyramid import httpexceptions
+from pyramid.renderers import JSON
+import six
+from sqlalchemy import engine_from_config, DateTime
+from sqlalchemy_utils import UUIDType
+from uuid import UUID
 
 from mediapublic import auth
 from mediapublic import exceptions as mp_exc
@@ -52,5 +54,15 @@ def main(global_config, **settings):
     config.add_view(hooks.handle_exceptions,
                     context=httpexceptions.HTTPForbidden,
                     permission=security.NO_PERMISSION_REQUIRED)
+
+    json_renderer = JSON()
+    def uuid_adapter(obj, request):
+        return six.text_type(obj) if obj != None else None
+    def datetime_adapter(obj, request):
+        return six.text_type(obj) if obj != None else None
+    json_renderer.add_adapter(UUIDType, uuid_adapter)
+    json_renderer.add_adapter(UUID, uuid_adapter)
+    # json_renderer.add_adapter(DateTime, datetime_adapter)
+    config.add_renderer('json', json_renderer)
 
     return config.make_wsgi_app()

--- a/server/mediapublic/models.py
+++ b/server/mediapublic/models.py
@@ -108,7 +108,7 @@ class CreationMixin():
 
     def to_dict(self):
         return {
-            'id': six.text_type(self.id),
+            'id': self.id,
             'creation_datetime': six.text_type(self.creation_datetime),
         }
 
@@ -198,8 +198,8 @@ class Users(Base, CreationMixin, TimeStampMixin, ExtraFieldMixin):
             display_name=self.display_name,
             twitter_handle=self.twitter_handle,
             email=self.email,
-            user_type=six.text_type(self.user_type_id),
-            organization_id=six.text_type(self.organization_id),
+            user_type=self.user_type_id,
+            organization_id=self.organization_id,
         )
 
     def to_dict(self):
@@ -500,8 +500,8 @@ class People(Base, CreationMixin, TimeStampMixin):
             facebook=self.facebook,
             instagram=self.instagram,
             periscope=self.periscope,
-            user_id=six.text_type(self.user_id),
-            organization_id=six.text_type(self.organization_id),
+            user_id=self.user_id,
+            organization_id=self.organization_id,
         )
 
     def to_dict(self):
@@ -545,8 +545,8 @@ class Recordings(Base, CreationMixin, TimeStampMixin):
         resp.update(
             title=self.title,
             url=self.url,
-            recorded_datetime=six.text_type(self.recorded_datetime),
-            organization_id=six.text_type(self.organization_id),
+            recorded_datetime=self.recorded_datetime,
+            organization_id=self.organization_id,
         )
         return resp
 


### PR DESCRIPTION
Fixes #126. Bonus: you don't have to remember to cast these types to strings when adding them to a model.

One oddity: I wasn't able to get rid of the one remaining cast of DateTime in models.py, kept throwing not serializable errors. I don't know why.

That was happening with the `id` property of each model too, until I added the adapter for `uuid.UUID`. That means that `id`s are `uuid.UUID`s but foreign keys are `sqlalchemy_util.UUIDType`. This is confusing, and makes me feel dirty, but isn't actually causing any problems, so I guess it's fine. I think there's something I don't understand about sqlalchemy's magic types. Any insight @ryansb or @thequbit?
