### PR TITLE
Add add links for each resource type for org admins on the org page.

### DIFF
--- a/client/app/helprequests/new/route.js
+++ b/client/app/helprequests/new/route.js
@@ -1,6 +1,7 @@
-import {Route} from 'backbone-routing';
-import View from '../show/view';
 import Model from 'shared/helprequests/model';
+import {Route} from 'backbone-routing';
+
+import View from '../show/view';
 
 export default Route.extend({
   initialize(options = {}) {
@@ -9,7 +10,9 @@ export default Route.extend({
 
   render() {
     this.view = new View({
-      model: new Model(),
+      model: new Model({
+        organization_id: app.currentUser.get('organization_id')
+      }),
       editing: true
     });
     this.container.show(this.view);

--- a/client/app/howtos/new/route.js
+++ b/client/app/howtos/new/route.js
@@ -1,6 +1,7 @@
-import {Route} from 'backbone-routing';
-import View from '../show/view';
 import Model from 'shared/howtos/model';
+import {Route} from 'backbone-routing';
+
+import View from '../show/view';
 
 export default Route.extend({
   initialize(options = {}) {
@@ -9,7 +10,9 @@ export default Route.extend({
 
   render() {
     this.view = new View({
-      model: new Model(),
+      model: new Model({
+        organization_id: app.currentUser.get('organization_id')
+      }),
       editing: true
     });
     this.container.show(this.view);

--- a/client/app/recordings/new/route.js
+++ b/client/app/recordings/new/route.js
@@ -1,6 +1,7 @@
-import {Route} from 'backbone-routing';
-import View from '../show/view';
 import Model from 'shared/recordings/model';
+import {Route} from 'backbone-routing';
+
+import View from '../show/view';
 
 export default Route.extend({
   initialize(options = {}) {
@@ -9,7 +10,9 @@ export default Route.extend({
 
   render() {
     this.view = new View({
-      model: new Model(),
+      model: new Model({
+        organization_id: app.currentUser.get('organization_id')
+      }),
       editing: true
     });
     this.container.show(this.view);

--- a/client/app/shared/forms/organizationselector.js
+++ b/client/app/shared/forms/organizationselector.js
@@ -1,8 +1,8 @@
-import Text from './text';
-import {organizations} from 'shared/search/datasets';
-import storage from 'shared/organizations/storage';
 import _ from 'underscore';
+import storage from 'shared/organizations/storage';
+import {organizations} from 'shared/search/datasets';
 
+import Text from './text';
 
 export default Text.extend({
   dataset: _.extend({}, organizations, {limit: 5}),
@@ -18,7 +18,7 @@ export default Text.extend({
         this.value = suggestion.id;
         this.preview = this.$el.val();
       });
-      this.$el.on('typeahead:change', (event) => {
+      this.$el.on('typeahead:change', () => {
         if (this.$el.val() !== this.preview) {
           this.value = '';
           this.$el.val('');

--- a/client/app/shared/helprequests/collectiontemplate.jade
+++ b/client/app/shared/helprequests/collectiontemplate.jade
@@ -1,6 +1,9 @@
 include ../templates/loadmore.jade
 
-if !viewState.isEmpty
-  h2.tile-list-title Ways to help
+if (!viewState.isEmpty || viewState.isOrgAdmin)
+  h2.tile-list-title
+    | Ways to help &nbsp;
+    if (viewState.isOrgAdmin)
+      a.fa.fa-plus(href="#/help-requests/new", title="Add a request for help.")
   .help-requests-list.tile-container
   +loadmore

--- a/client/app/shared/helprequests/collectionview.js
+++ b/client/app/shared/helprequests/collectionview.js
@@ -1,7 +1,7 @@
 import CompositeView from 'shared/views/compositeview';
-import SingleView from './singleview';
-import Model from './model';
+
 import template from './collectiontemplate.jade';
+import SingleView from './singleview';
 
 export default CompositeView.extend({
   template,

--- a/client/app/shared/howtos/collectiontemplate.jade
+++ b/client/app/shared/howtos/collectiontemplate.jade
@@ -1,6 +1,9 @@
 include ../templates/loadmore.jade
 
-if !viewState.isEmpty
-  h2.tile-list-title Howtos
+if (!viewState.isEmpty || viewState.isOrgAdmin)
+  h2.tile-list-title
+   | Howtos &nbsp;
+   if (viewState.isOrgAdmin)
+     a.fa.fa-plus(href="#/howtos/new", title="Write a howto to share your institutional knowledge.")
   .howtos-list.tile-container
   +loadmore

--- a/client/app/shared/people/collectiontemplate.jade
+++ b/client/app/shared/people/collectiontemplate.jade
@@ -1,6 +1,9 @@
 include ../templates/loadmore.jade
 
-if !viewState.isEmpty
-  h2.tile-list-title People
+if (!viewState.isEmpty || viewState.isOrgAdmin)
+  h2.tile-list-title
+    | People&nbsp;
+    if (viewState.isOrgAdmin)
+      a.fa.fa-plus(href="#/people/new", title="List a person in your organization.")
   .people-list.tile-container
   +loadmore

--- a/client/app/shared/recordings/collectiontemplate.jade
+++ b/client/app/shared/recordings/collectiontemplate.jade
@@ -1,6 +1,9 @@
 include ../templates/loadmore.jade
 
-if !viewState.isEmpty
-  h2.tile-list-title Recordings
+if (!viewState.isEmpty || viewState.isOrgAdmin)
+  h2.tile-list-title
+    | Recordings &nbsp;
+    if (viewState.isOrgAdmin)
+      a.fa.fa-plus(href="#/recordings/new", title="Add a recording to your organization.")
   .recordings-list.tile-container
   +loadmore

--- a/client/app/shared/views/compositeview.js
+++ b/client/app/shared/views/compositeview.js
@@ -1,11 +1,13 @@
-import {CompositeView} from 'backbone.marionette';
 import {Model} from 'backbone';
+import {CompositeView} from 'backbone.marionette';
 
 export default CompositeView.extend({
   initialize(options) {
     this.state = new Model({
       more: options.more || false,
     });
+    this.updatePermissions();
+    this.listenTo(app.currentUser, 'change', this.updatePermissions);
     this.updateState();
     this.listenTo(this.state, 'change', this.render);
     this.listenTo(this.collection, 'sync', this.updateState);
@@ -48,5 +50,11 @@ export default CompositeView.extend({
       isEmpty: !this.collection ||
           (!this.collection.fetchInProgress && this.collection.length === 0)
     });
+  },
+
+  updatePermissions() {
+    this.state.set(
+      'isOrgAdmin',
+      app.currentUser.isOrgAdmin(this.collection.organization));
   }
 });

--- a/client/app/shared/views/itemview.js
+++ b/client/app/shared/views/itemview.js
@@ -1,9 +1,8 @@
-import {ItemView} from 'backbone.marionette';
-import Backbone from 'backbone';
-import {Model} from 'backbone';
 import _ from 'underscore';
+import Backbone from 'backbone';
 import Form from 'shared/forms/distributed';
-
+import {Model} from 'backbone';
+import {ItemView} from 'backbone.marionette';
 
 /**
  * Standard ItemView, extended to include the model cid in all serialized data.
@@ -150,7 +149,11 @@ export default ItemView.extend({
 
   updatePermissions() {
     this.state.set('canUserEdit',
+        // If you're not logged in or there's nothing to edit, then no.
         app.currentUser && this.model &&
-        (this.model.canUserEdit(app.currentUser) || app.currentUser.isAdmin()));
+        // If you're an admin, or the model says it's ok, then yes.
+        (this.model.canUserEdit(app.currentUser) || app.currentUser.isAdmin()) ||
+        // If this is a new page, and you're some kinda admin, then yes.
+        this.model.isNew() && app.currentUser.get('is_org_admin'));
   }
 });

--- a/client/app/users/new/route.js
+++ b/client/app/users/new/route.js
@@ -1,6 +1,7 @@
-import {Route} from 'backbone-routing';
-import View from '../show/view';
 import Person from 'shared/people/person';
+import {Route} from 'backbone-routing';
+
+import View from '../show/view';
 
 export default Route.extend({
   initialize(options = {}) {
@@ -9,7 +10,10 @@ export default Route.extend({
 
   render() {
     this.view = new View({
-      model: new Person(),
+      model: new Person({
+        organization_id: app.currentUser.get('organization_id'),
+        org_approved: app.currentUser.get('is_org_admin')
+      }),
       editing: true
     });
     this.container.show(this.view);


### PR DESCRIPTION
Org admins now have little '+' icons at the top of each list of sub-resources that link them to the page where they can add that resource. The organization_id of the new item is pre-filled so it actually shows up on the org page. Navigating back is really hard (we need breadcrumbs), but it basically works!
